### PR TITLE
Separate public movie data from private movie userdata

### DIFF
--- a/app/middlewares/authMiddleware.js
+++ b/app/middlewares/authMiddleware.js
@@ -28,31 +28,4 @@ async function verifyToken(req, _, next) {
   }
 }
 
-async function optionalToken(req, _, next) {
-  try {
-    const token = req.headers["authorization"]?.slice(7);
-    const fingerprint = req.cookies?.fingerprint;
-    if (!token || !fingerprint) {
-      console.log("No token or fingerprint provided!");
-      return next(); // If there's no token or fingerprint, just move on.
-    }
-    const decoded = jwt.decode(token, process.env.TOKEN_SECRET); // verify token
-    const hashedFingerprint = hashToken(fingerprint);
-    if (decoded.fingerprint !== hashedFingerprint) {
-      console.log("Invalid fingerprint");
-      return next(); // Invalid fingerprint, move on without error
-    }
-    req.userId = decoded.id; // add the user id to the request
-  } catch (error) {
-    // console.error(error);
-    // Handle specific JWT errors but do not throw them
-    if (error instanceof jwt.JsonWebTokenError || error instanceof jwt.TokenExpiredError) {
-      console.log("Invalid or expired token");
-      return next(); // Invalid token, move on without setting userId
-    }
-  }
-
-  next();
-}
-
-export { optionalToken, verifyToken };
+export { verifyToken };

--- a/app/routers/api/movies.router.js
+++ b/app/routers/api/movies.router.js
@@ -107,6 +107,22 @@ router.get(
 );
 
 /**
+ * GET /api/movie/:id/userdata
+ * @summary Get userdata about a movie
+ * @tags Movies
+ * @param {string} id.params.required - movie id
+ * @return {Movie} 200 - success response
+ * @return {ApiError} 400 - bad input response
+ * @return {ApiError} 500 - internal server error response
+ */
+router.get(
+  "/:id/userdata",
+  verifyToken,
+  validationMiddleware({ params: genericSchema.paramsId }),
+  controllerWrapper(moviesController.getUserdataAboutMovieById)
+);
+
+/**
  * GET /api/movie
  * @summary Get movies with parameters
  * @tags Movies

--- a/app/routers/api/movies.router.js
+++ b/app/routers/api/movies.router.js
@@ -26,6 +26,30 @@ const router = express.Router();
  */
 
 /**
+ * A rating object
+ * @typedef {object} Rating
+ * @property {number} rating_id - The rating id
+ * @property {number} value - The rating value
+ */
+
+/**
+ * A review object
+ * @typedef {object} Review
+ * @property {number} review_id - The review id
+ * @property {string} content - The review content
+ */
+
+/**
+ * A movie userdata object
+ * @typedef {object} MovieUserdata
+ * @property {number} user_id - The user id
+ * @property {Rating} rating - The rating object
+ * @property {Review} review - The review object
+ * @property {boolean} viewed - The viewed status
+ * @property {Array<number>} in_playlists - The list of playlists id where the movie is
+ */
+
+/**
  * GET /api/movie/genre
  * @summary Get movie genres
  * @tags Movies
@@ -110,7 +134,7 @@ router.get(
  * @summary Get userdata about a movie
  * @tags Movies
  * @param {string} id.params.required - movie id
- * @return {Movie} 200 - success response
+ * @return {MovieUserdata} 200 - success response
  * @return {ApiError} 400 - bad input response
  * @return {ApiError} 500 - internal server error response
  */

--- a/app/routers/api/movies.router.js
+++ b/app/routers/api/movies.router.js
@@ -1,6 +1,6 @@
 import express from "express";
 import moviesController from "../../controllers/moviesController.js";
-import { optionalToken } from "../../middlewares/authMiddleware.js";
+import { verifyToken } from "../../middlewares/authMiddleware.js";
 import controllerWrapper from "../../middlewares/controllerWrapper.js";
 import validationMiddleware from "../../middlewares/validationMiddleware.js";
 import genericSchema from "../../validation/genericSchemas.js";
@@ -101,7 +101,6 @@ router.get("/toprated", controllerWrapper(moviesController.getTopRatedMovies));
  */
 router.get(
   "/:id",
-  optionalToken,
   validationMiddleware({ params: genericSchema.paramsId }),
   controllerWrapper(moviesController.getMovieById)
 );


### PR DESCRIPTION
With this PR, userdata is not provided anymore in a request for a movie by id.
A new route with credentials is created to get userdata about a movie : `/movie/:id/userdata`

User data for a movie looks like this :
```json
{
  "user_id": 38,
  "rating": {
    "value": 5,
    "rating_id": 64
  },
  "review": {
    "content": "Génial",
    "review_id": 109
  },
  "viewed": false,
  "in_playlists": []
}
```

To be merged after :
-  #2 