### PR TITLE
Improve unit tests so they don't request the database

### DIFF
--- a/app/models/sequelizeClient.js
+++ b/app/models/sequelizeClient.js
@@ -14,4 +14,12 @@ Sequelize.postgres.DECIMAL.parse = function (value) {
   return parseFloat(value);
 };
 
-await sequelize.authenticate();
+export async function testDbConnection() {
+  try {
+    await sequelize.authenticate();
+    console.log("✅ Database connection established successfully.");
+  } catch (error) {
+    console.error("❌ Unable to connect to the database:", error);
+    process.exit(1);
+  }
+}

--- a/index.js
+++ b/index.js
@@ -2,8 +2,11 @@ import { createServer } from "node:http";
 import "dotenv/config";
 
 import app from "./app/index.app.js";
+import { testDbConnection } from "./app/models/sequelizeClient.js";
 
 const PORT = process.env.PORT || 3000;
+
+await testDbConnection();
 
 const httpServer = createServer(app);
 

--- a/test/profil.controller.test.js
+++ b/test/profil.controller.test.js
@@ -1,27 +1,55 @@
-import { describe, it } from "mocha";
+import { describe, it, beforeEach, afterEach } from "mocha";
 import { expect } from "chai";
+import sinon from "sinon";
+import { User, Review, Rating } from "../app/models/associations.js";
 import profilController from "../app/controllers/profilController.js";
 
 describe("profilController", () => {
   describe("getProfil", () => {
+    let res;
+
+    beforeEach(() => {
+      res = { json: sinon.spy() };
+
+      sinon.stub(User, "findOne");
+      sinon.stub(Review, "count");
+      sinon.stub(Rating, "count");
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
     it("should return a success status and data object", async () => {
-      const req = { userId: 1 }; // Simulate a request object with a userId
-      const res = {
-        json: (data) => data, // Simulate a json method that returns the data passed as an argument
+      const req = { userId: 1 };
+
+      const fakeUserData = {
+        dataValues: {
+          id: 1,
+          firstname: "John",
+          lastname: "Doe",
+          email: "john@example.com",
+          birthdate: "1990-01-01",
+        },
       };
 
-      const response = await profilController.getProfil(req, res);
+      User.findOne.resolves(fakeUserData);
+      Review.count.resolves(5);
+      Rating.count.resolves(10);
 
-      // Verify that the response is an object with the expected properties
+      await profilController.getProfil(req, res);
+
+      expect(res.json.calledOnce).to.be.true;
+      const response = res.json.firstCall.args[0];
+
       expect(response).to.be.an("object");
       expect(response).to.have.property("status", "success");
       expect(response).to.have.property("data").that.is.an("object");
 
-      // Verify that the data object has the expected properties
       const { data } = response;
-      expect(data).to.have.property("id");
-      expect(data).to.have.property("count_review").that.is.a("number");
-      expect(data).to.have.property("count_rating").that.is.a("number");
+      expect(data).to.have.property("id", 1);
+      expect(data).to.have.property("count_review", 5);
+      expect(data).to.have.property("count_rating", 10);
     });
   });
 });


### PR DESCRIPTION
Don't try to connect to database on sequelizeClient module import (fails for unit tests)  
Use stubs in profilController tests so they can pass without requesting a real database  